### PR TITLE
Add custom variable support to haproxy_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Attributes
 - `node['haproxy']['pool_members']` - updated by discovery to store node information
 - `node['haproxy']['conf_cookbook']` - used to update which cookbook holds the haproxy.cfg template
 - `node['haproxy']['conf_template_source']` - name of the haproxy.cfg template
+- `node['haproxy']['conf_template_variables']` - custom variables to pass to the haproxy.cfg template
 
 Recipes
 -------
@@ -174,6 +175,22 @@ haproxy_config "Write Config" do
   conf_template_source node['haproxy']['conf_template_source']
 end
 ```
+
+#### haproxy_config with custom variables
+
+The `conf_template_variables` resource can be used to pass a hash of custom variables to your haproxy.cfg template.
+
+```
+haproxy_config "Write Config" do
+  conf_dir node['haproxy']['conf_dir']
+  conf_cookbook node['haproxy']['conf_cookbook']
+  conf_template_source 'custom.haproxy.cfg.erb'
+  conf_template_variables enable_ssl: true,
+                          instance_ips: [192.168.0.1, 192.168.0.1]
+end
+```
+
+These variables can then be accessed in your template as `@conf_template_variables`
 
 ### haproxy
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs and configures haproxy"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.6.6"
+version           "1.6.7"
 
 recipe "haproxy", "Installs and configures haproxy"
 recipe "haproxy::app_lb", "Installs and configures haproxy by searching for nodes of a particular role"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs and configures haproxy"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.6.7"
+version           "1.6.6"
 
 recipe "haproxy", "Installs and configures haproxy"
 recipe "haproxy::app_lb", "Installs and configures haproxy by searching for nodes of a particular role"

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -17,7 +17,8 @@ def install_haproxy_config
     mode 00644
     variables(
       :defaults_options => defaults_options,
-      :defaults_timeouts => defaults_timeouts
+      :defaults_timeouts => defaults_timeouts,
+      :conf_template_variables => new_resource.conf_template_variables
     )
   end
 end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -8,9 +8,11 @@ def initialize(*args)
   conf_dir(node["haproxy"]["conf_dir"]) if conf_dir.nil?
   conf_cookbook(node["haproxy"]["conf_cookbook"]) if conf_cookbook.nil?
   conf_template_source(node["haproxy"]["conf_template_source"]) if conf_template_source.nil?
+  conf_template_variables(node["haproxy"]["conf_template_variables"]) if conf_template_variables.nil?
 end
 
 attribute :name, :kind_of => String, :name_attribute => true
 attribute :conf_dir, :kind_of => String, :default => nil
 attribute :conf_cookbook, :kind_of => String, :default => nil
 attribute :conf_template_source, :kind_of => String, :default => nil
+attribute :conf_template_variables, :kind_of => Hash, :default => nil


### PR DESCRIPTION
This allows passing of custom variables to the haproxy template via the `conf_template_variables` resource.
